### PR TITLE
Make the javadoc compile under JDK 8

### DIFF
--- a/segment/pom.xml
+++ b/segment/pom.xml
@@ -41,6 +41,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+		<additionalparam>-Xdoclint:none</additionalparam>		
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Add global property to fix javadoc problems, otherwise it won't compile cleanly under Java 8.
